### PR TITLE
Sampling rate in demo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This example assumes an otherwise correctly configured Alfresco service to be co
 
 #### Enabling tracing on requests
 
-Only a certain percentage of requests will be traced and reported to your Zipkin collector. By default we set this percentage to 0 (because we use the Chrome browser plugin). There are two ways to have your requests traced.
+Only a certain percentage of requests will be traced and reported to your Zipkin collector. There are two ways to have your requests traced.
 
 ##### 1) alfresco-global.properties
 
@@ -65,7 +65,9 @@ The value should be set between `0.0` and `1.0`, signifying respectively no trac
 
 ##### 2) Chrome browser plugin
 
-There is a [Chrome browser plugin](https://chrome.google.com/webstore/detail/zipkin-browser-extension/jdpmaacocdhbmkppghmgnjmfikeeldfe) made by Zipkin that can be used for toggling whether to add the tracing headers to your browser requests and send tracing information to a span collector of your choice. This is very convenient for local development. 
+There was a [Chrome browser plugin](https://chrome.google.com/webstore/detail/zipkin-browser-extension/jdpmaacocdhbmkppghmgnjmfikeeldfe) made by the Zipkin team that can be used for toggling whether to add the tracing headers to your browser requests and send tracing information to a span collector of your choice. This was very convenient for local development. 
+
+However it seems that it is no longer available on the Chrome Webstore. You might still be able to build it yourself (also for Firefox). [zipkin-browser-extension](https://github.com/openzipkin/zipkin-browser-extension) 
 
 
 ### P6spy

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "eu.xenit.docker-compose" version "5.0.7" apply false
+    id "eu.xenit.docker-compose" version "5.2.0" apply false
 }
 
 allprojects {

--- a/integration-tests/src/integration-test/java/eu/xenit/alfresco/instrumentation/ZipkinTraceTest.java
+++ b/integration-tests/src/integration-test/java/eu/xenit/alfresco/instrumentation/ZipkinTraceTest.java
@@ -109,6 +109,9 @@ public class ZipkinTraceTest {
 
     private String randomTraceId() {
         long longTraceId = java.util.concurrent.ThreadLocalRandom.current().nextLong();
-        return Long.toHexString(longTraceId);
+        String s = Long.toHexString(longTraceId);
+        // if (length == 15) throw new RuntimeException("WTF");
+        // https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin2/Span.java#L638
+        return s.length() == 15 ? "0" + s : s;
     }
 }

--- a/integration-tests/src/integration-test/resources/compose/docker-compose-zipkin.yml
+++ b/integration-tests/src/integration-test/resources/compose/docker-compose-zipkin.yml
@@ -6,6 +6,10 @@ services:
     - DB_DRIVER=com.p6spy.engine.spy.P6SpyDriver
     - DB_URL=${COMPOSE_DB_URL:-jdbc:p6spy:postgresql://database:5432/alfresco}
     - GLOBAL_zipkin.collector=http://zipkin:9411/api/v2/spans
+    # sampling on 1.0 for demo purposes
+    - GLOBAL_zipkin.service.alfresco.sampler.rate=1.0
+    - GLOBAL_zipkin.service.solr.sampler.rate=1.0
+    - GLOBAL_zipkin.service.share.sampler.rate=1.0
     - INDEX=solr4
 
   share:


### PR DESCRIPTION
Zipkin chrome plugin is not available anymore in Chrome Webstore.
I set the sampling rate in our demo setup to 1.0 

I also:
* edited the readme to reflect this change
* bumped our docker-compose plugin version
* made a change to counter integration tests failing sometimes.