### PR TITLE
XENOPS-794 enable publishing maven artifacts and docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
           ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: ./gradlew publish
-#      - name: Publish docker images
-#        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-#        env:
-#          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-#          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-#        run: ./gradlew pushDockerImage
+      - name: Publish docker images
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: ./gradlew pushDockerImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,3 @@ jobs:
           ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: ./gradlew publish
-      - name: Publish docker images
-        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: ./gradlew pushDockerImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
       #          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       #          GITHUB_TOKEN: ${{ github.token }}
       #        run: ./gradlew sonarqube -Dsonar.projectKey=xenit-eu_alfresco-gradle-sdk -Dsonar.organization=xenit-eu -Dsonar.host.url=https://sonarcloud.io
-#      - name: Publish
-#        if: ${{ github.ref == 'refs/heads/master' || startswith(github.ref, 'refs/tags/') }}
-#        env:
-#          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_CENTRAL_GPG_KEY }}
-#          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_CENTRAL_GPG_PASSWORD }}
-#          ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-#          ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-#        run: ./gradlew publish
+      - name: Publish
+        if: ${{ github.ref == 'refs/heads/master' || startswith(github.ref, 'refs/tags/') }}
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_CENTRAL_GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_CENTRAL_GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: ./gradlew publish
 #      - name: Publish docker images
 #        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
 #        env:

--- a/publish.gradle
+++ b/publish.gradle
@@ -37,32 +37,15 @@ publishing {
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
             credentials {
-                username = project.hasProperty('publish_username') ? project.publish_username : ''
-                password = project.hasProperty('publish_password') ? project.publish_password : ''
+                username = project.hasProperty('sonatype_username') ? project.sonatype_username : ''
+                password = project.hasProperty('sonatype_password') ? project.sonatype_password : ''
             }
         }
     }
 }
 
-afterEvaluate {
-    signing {
-        required { !version.endsWith('SNAPSHOT') && gradle.taskGraph.hasTask("publish") }
-        sign publishing.publications
-    }
-}
-
-gradle.taskGraph.whenReady { graph ->
-    if (graph.hasTask(publish)) {
-        if (!project.hasProperty('keyId') || !project.hasProperty('secretKeyRingFile') || !project.hasProperty('password')) {
-            throw new GradleException('You need to provide signing params in order to sign artifacts')
-        }
-
-        def id = project.hasProperty('keyId') ? project.keyId : ''
-        def file = project.hasProperty('secretKeyRingFile') ? project.secretKeyRingFile : ''
-        def password = project.hasProperty('password') ? project.password : ''
-
-        ext."signing.keyId" = id
-        ext."signing.secretKeyRingFile" = file
-        ext."signing.password" = password
-    }
+signing {
+    required { !version.toString().endsWith("SNAPSHOT") }
+    useInMemoryPgpKeys(findProperty("signingKey"), findProperty("signingPassword"))
+    sign publishing.publications
 }


### PR DESCRIPTION
maven publication has been tested with XENOPS-794-2-tmp branch
It published a v0.0.0 release artifact by making a temporary GH release tag
Branch will be removed after this PR.

![image](https://user-images.githubusercontent.com/14177727/111453456-e3265280-8713-11eb-8cb7-f07184f2f570.png)
artifacts were removed from staging after this verification that publishing works